### PR TITLE
docs: añadir documentación inicial del sistema de agendamiento

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,85 @@
+# Agendamiento Planta 1
+
+## 🧭 Propósito
+Sistema web integral para gestionar el agendamiento de turnos de vehículos en planta. Permite a conductores y planners coordinar cupos, validar documentos, monitorear estados en tiempo real y analizar KPIs operativos.
+
+## ⚙️ Tecnologías propuestas
+- **Frontend:** Next.js 15, React 19, TypeScript, TailwindCSS, shadcn/ui, Framer Motion, React Query, i18next.
+- **Backend:** Next.js API Routes, Prisma ORM, Zod, BullMQ (Redis) para colas, Webhooks.
+- **Infraestructura:** PostgreSQL 15, Redis, Docker Compose, Caddy como reverse proxy, OpenTelemetry, Sentry.
+
+## 🧱 Módulos clave
+1. Panel de usuario (creación, consulta, cancelación y reprogramación de turnos).
+2. Panel de administración con agenda en tiempo real, reglas y asignación de muelles.
+3. Motor de reglas dinámico con validaciones y priorizaciones.
+4. Gestión documental y validaciones automáticas.
+5. Sistema de notificaciones multicanal (WhatsApp, email, SMS opcional).
+6. KPIs y simulador de capacidad para análisis operativo.
+
+## 🚀 Instalación rápida
+```bash
+git clone https://github.com/yumatech/agendamiento.git
+cd agendamiento
+cp .env.example .env
+docker compose up -d --build
+```
+
+### Desarrollo local
+```bash
+npm install
+npm run dev
+```
+
+### Pruebas y mantenimiento
+- `npm run test` — pruebas unitarias y E2E.
+- `npx prisma migrate deploy` — aplicar migraciones.
+- `npx prisma studio` — inspección de datos.
+
+## 👤 Acceso demo
+- Usuario: `admin@demo.com`
+- Contraseña: `Admin123!`
+
+## 📁 Estructura propuesta del repositorio
+```
+agendamiento/
+├── app/                     # Next.js (App Router + API)
+│   ├── app/                 # layouts, rutas públicas e internas
+│   ├── components/          # UI shadcn + componentes propios
+│   ├── features/            # módulos: turnos, reglas, admin, user
+│   ├── lib/                 # contratos, hooks, helpers, cliente API
+│   ├── server/              # servicios Prisma, reglas, colas
+│   ├── prisma/              # esquema y migraciones
+│   ├── public/              # assets estáticos
+│   └── tests/               # pruebas unitarias y E2E
+├── deploy/                  # infraestructura (docker, caddy, scripts)
+├── docs/                    # documentación funcional y técnica
+├── .env.example
+├── package.json
+└── README.md
+```
+
+## 📚 Documentación disponible
+- [Arquitectura](docs/arquitectura.md)
+- [API y casos de uso](docs/api.md)
+- [Modelo de datos](docs/base_datos.md)
+- [Reglas y KPIs](docs/reglas_y_kpi.md)
+- [Lineamientos UI/UX](docs/ui_ux.md)
+- [Seguridad y CI/CD](docs/seguridad_y_ci_cd.md)
+- [Manual de usuario](docs/manual_usuario.md)
+
+## ✅ Checklist de entrega
+- Documentación funcional y técnica.
+- Esquema de base de datos y migraciones.
+- API y casos de uso principales.
+- UI/UX detallado con flujos clave.
+- Módulo de KPIs y simulador documentado.
+- Docker + CI/CD descritos.
+- Manual técnico y de usuario.
+- Seguridad, respaldos y monitoreo cubiertos.
+
+## 🔭 Próximos pasos sugeridos
+- Integrar SSO corporativo (Azure AD / Keycloak).
+- Añadir permisos granulares por scopes.
+- Extender simulador con predicciones (Prophet).
+- Exponer API externa REST/GraphQL con OpenAPI.
+- Integrar con Power BI / Power Automate para reportes.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,85 @@
+# API y casos de uso
+
+## Principios generales
+- Todas las entradas se validan con Zod y devuelven errores explícitos.
+- Autenticación vía Auth.js con JWT; scopes RBAC (`admin`, `planner`, `operativo`, `guardia`, `usuario`).
+- Respuestas JSON con metadatos de auditoría y enlaces de navegación.
+- Rate limiting y logging de auditoría en cada mutación.
+
+## Máquina de estados del turno
+```
+CREADO → VALIDANDO → CONFIRMADO → EN_PROCESO → ATENDIDO → CERRADO
+            ↓                   ↓
+        RECHAZADO         CANCELADO_USUARIO
+                               CANCELADO_ADMIN
+                               NO_SHOW
+```
+Las transiciones se controlan en server actions respaldadas por el motor de reglas.
+
+## Casos de uso principales
+### Portal de usuario
+1. **Crear turno**
+   - `POST /api/turnos`
+   - Valida cédula/placa, reglas vigentes y disponibilidad de franja.
+   - Retorna QR, confirmación por WhatsApp/email y resumen del turno.
+2. **Consultar turnos propios**
+   - `GET /api/turnos?usuario=me`
+   - Soporta filtros por fecha, estado y planta.
+3. **Cancelar turno**
+   - `POST /api/turnos/{id}/cancelar`
+   - Evalúa tolerancia; si se excede responde con mensaje para contactar al operador.
+4. **Reprogramar turno**
+   - `POST /api/turnos/{id}/reprogramar`
+   - Revalida reglas y disponibilidad antes de confirmar la nueva franja.
+
+### Panel de administración
+1. **Agenda y asignación de muelles**
+   - `GET /api/agenda?planta={id}&fecha={yyyy-mm-dd}` retorna slots por hora y muelle.
+   - `POST /api/agenda/{turnoId}/asignar` con `muelle_id` y `prioridad`.
+   - Drag & drop en UI dispara actualización; si hay solape devuelve error tipo toast.
+2. **Gestión de reglas**
+   - `GET /api/reglas`
+   - `POST /api/reglas` para crear reglas (`tipo_regla`, `condiciones`, `accion`).
+   - `PATCH /api/reglas/{id}` para activar/desactivar o ajustar parámetros.
+3. **Validación documental**
+   - `POST /api/documentos/upload` con metadata (`tipo_documento`, `vigencia`).
+   - Integración con servicios externos para verificación opcional.
+4. **Notificaciones**
+   - `POST /api/notificaciones/reenviar` para forzar un reenvío.
+   - Registro histórico en `/api/turnos/{id}/comunicaciones`.
+5. **Simulador de agenda**
+   - `POST /api/simulador` recibe `cupos_por_franja`, `duracion_promedio`, `horizonte`.
+   - Devuelve proyección en JSON usada para charts de capacidad.
+
+### Auditoría y reporting
+- `GET /api/auditoria` lista eventos con filtros (usuario, módulo, rango fechas).
+- `GET /api/kpis` agrupa métricas clave (turnos por estado, ocupación, SLA, cancelaciones).
+- `GET /api/kpis/heatmap` genera ocupación semanal por muelle.
+
+## Contratos destacados
+```ts
+// Ejemplo de creación de turno
+const CrearTurnoSchema = z.object({
+  plantaId: z.string().uuid(),
+  fecha: z.string().date(),
+  hora: z.string(),
+  cedula: z.string().min(5),
+  placa: z.string().toUpperCase(),
+  tipoVehiculo: z.enum(["TRACTOMULA","CAMIONETA","DOBLE_TROQUE","OTRO"]),
+  documentos: z.array(z.object({
+    tipo: z.enum(["LICENCIA","SOAT","TECNICOMECANICA","TARJETA_PROPIEDAD","CEDULA","OTRO"]),
+    url: z.string().url(),
+    vigencia: z.string().date().optional()
+  }))
+});
+```
+
+## Webhooks y eventos
+- **Webhook externo:** `/api/webhooks/turnos` envía eventos `CREADO`, `CONFIRMADO`, `CANCELADO`, `NO_SHOW`.
+- **Worker BullMQ:** colas `notificaciones`, `recordatorios`, `kpi_snapshots`.
+- **Notificaciones:** plantillas con variables (`turno.codigo`, `planta.nombre`, `fecha_formateada`).
+
+## Manejo de errores
+- Códigos estandarizados (`RULE_VIOLATION`, `CAPACITY_EXCEEDED`, `DOCUMENTO_VENCIDO`).
+- Respuestas con `traceId` para correlacionar en OpenTelemetry.
+- Mensajes de usuario en español e inglés listos para i18n.

--- a/docs/arquitectura.md
+++ b/docs/arquitectura.md
@@ -1,0 +1,45 @@
+# Arquitectura técnica
+
+## Visión general
+El sistema combina un frontend Next.js 15 (App Router) y un backend basado en rutas API y server actions para procesar la lógica de agendamiento. Se priorizan componentes de servidor para listados extensos, mientras que formularios y dashboards funcionan como componentes cliente con React Query para mutaciones y revalidaciones.
+
+## Frontend
+- **Tecnologías:** React 19 con TypeScript, TailwindCSS, shadcn/ui, Framer Motion para microinteracciones, i18next para internacionalización ES/EN.
+- **Estructura:** módulos funcionales en `features/` (turnos, reglas, admin, user) respaldados por componentes reutilizables en `components/` y utilidades compartidas en `lib/`.
+- **Estado y datos:** React Query gestiona caché y sincronización tras mutaciones; formularios usan React Hook Form + Zod.
+- **UX adicional:** tema claro/oscuro, soporte mobile-first, accesibilidad AA y loaders skeleton con shimmer.
+
+## Backend
+- **Framework:** Next.js API Routes y server actions.
+- **Persistencia:** Prisma ORM conectado a PostgreSQL 15 con migraciones versionadas.
+- **Validaciones:** Zod para contratos; motor de reglas configurable con acciones `RECHAZAR`, `PRIORIZAR` o `WARN`.
+- **Colas y jobs:** BullMQ con Redis para notificaciones, recordatorios y procesamientos diferidos.
+- **Integraciones:** webhooks hacia sistemas externos (Power Automate, ERP), servicio WhatsApp Business API, SMTP para email y generación de PDFs/QR.
+
+## Infraestructura
+- **Contenedores:** Docker Compose orquesta servicios (app, PostgreSQL, Redis, Caddy).
+- **Reverse proxy:** Caddy con certificados SSL automáticos.
+- **Despliegue:** VPS Ubuntu 24.04; pipeline CI/CD en GitHub Actions con lint, tests y build antes de desplegar.
+- **Escalabilidad:** posibilidad de separar workers BullMQ y habilitar CDN para assets.
+
+## Observabilidad y monitoreo
+- Logging estructurado con `pino` y formateo local `pino-pretty`.
+- OpenTelemetry para traces y métricas.
+- Sentry captura errores front y backend.
+- Healthchecks expuestos para monitoreo externo y alertas vía email/Telegram.
+
+## Seguridad
+- Autenticación con Auth.js/NextAuth (credenciales y SSO corporativo opcional) y soporte 2FA.
+- Rate limiting con Redis, headers de seguridad (Helmet) y CORS configurado.
+- Auditoría con registros de usuario, IP, acción y cambios.
+- Cifrado en reposo para datos sensibles y política de backups verificados.
+
+## Respaldo y continuidad
+- Backups automáticos usando `pg_dump` y posible integración con `restic`.
+- Scripts de `deploy/scripts/backup.sh` y `restore.sh` para recuperación rápida.
+- Estrategia de retención 30/90 días y pruebas periódicas de restauración.
+
+## Roadmap técnico
+- Implementar SSO corporativo (Azure AD/Keycloak).
+- Añadir permisos granulares y scopes.
+- Optimizar simulador con modelos predictivos (Prophet) y exponer API pública documentada.

--- a/docs/base_datos.md
+++ b/docs/base_datos.md
@@ -1,0 +1,128 @@
+# Modelo de datos (PostgreSQL + Prisma)
+
+## Enums principales
+- `Idioma`: `ES`, `EN`.
+- `TemaUI`: `SYSTEM`, `LIGHT`, `DARK`.
+- `TipoVehiculo`: `TRACTOMULA`, `DOBLE_TROQUE`, `CAMIONETA`, `SPRINTER`, `MOTO`, `OTRO`.
+- `TurnoEstado`: `CREADO`, `VALIDANDO`, `CONFIRMADO`, `EN_PROCESO`, `ATENDIDO`, `CERRADO`, `RECHAZADO`, `CANCELADO_USUARIO`, `CANCELADO_ADMIN`, `NO_SHOW`.
+- `TipoDocumento`: `LICENCIA`, `SOAT`, `TECNICOMECANICA`, `TARJETA_PROPIEDAD`, `CEDULA`, `OTRO`.
+- `TipoRegla`: `MAX_POR_EMPRESA`, `BLOQUEO_TIPO_VEHICULO`, `PRIORIDAD_PROVEEDOR`, `DOCUMENTO_OBLIGATORIO`, `CAPACIDAD_DIA`, `CAPACIDAD_FRANJA`, `TOLERANCIA_CANCELACION`, `VENTANILLA_OBLIGATORIA`.
+
+## Tablas núcleo
+### usuarios
+- `id` (PK, uuid)
+- `email` (varchar(150), único, no nulo)
+- `nombre` (varchar(120))
+- `telefono` (varchar(20))
+- `idioma` (`Idioma`, default `ES`)
+- `tema_ui` (`TemaUI`, default `SYSTEM`)
+- `activo` (boolean, default true)
+- `created_at`, `updated_at`
+- Índices: `idx_usuarios_email_unique`, `idx_usuarios_activo`
+
+### roles
+- `id` (PK)
+- `nombre` (varchar(50), único) — valores: `admin`, `planner`, `operativo`, `guardia`, `usuario`
+- `descripcion` (varchar(200))
+
+### usuario_roles
+- `usuario_id` (FK → usuarios.id, cascade)
+- `rol_id` (FK → roles.id, restrict)
+- PK compuesta `(usuario_id, rol_id)`
+
+### empresas
+- `id` (PK)
+- `nit` (varchar(30), único, no nulo)
+- `razon_social` (varchar(150), no nulo)
+- `contacto`, `telefono`, `email`
+- `activa` (boolean, default true)
+- Timestamps e índices `idx_empresas_nit_unique`, `idx_empresas_activa`
+
+### conductores
+- `id` (PK)
+- `cedula` (varchar(20), único, no nulo)
+- `nombre` (varchar(120), no nulo)
+- `telefono`, `email`
+- `empresa_id` (FK → empresas.id, set null)
+- `activo` (boolean, default true)
+- Índices: `idx_conductores_cedula_unique`, `idx_conductores_empresa`, `idx_conductores_activo`
+
+### vehiculos
+- `id` (PK)
+- `placa` (varchar(10), único, uppercase)
+- `tipo` (`TipoVehiculo`, no nulo)
+- `empresa_id` (FK → empresas.id, set null)
+- `capacidad_tn` (numeric(6,2))
+- `activo` (boolean, default true)
+- Índices: `idx_vehiculos_placa_unique`, `idx_vehiculos_empresa`, `idx_vehiculos_activo`
+
+### plantas
+- `id` (PK)
+- `nombre` (varchar(120), único, no nulo)
+- `direccion` (varchar(200))
+- `timezone` (varchar(60), default `America/Bogota`)
+- `activo` (boolean, default true)
+
+### muelles
+- `id` (PK)
+- `planta_id` (FK → plantas.id, cascade)
+- `nombre` (varchar(60), no nulo)
+- `activo` (boolean, default true)
+- Índice único `(planta_id, nombre)`
+
+### ventanillas
+- Similar a muelles, opcional para prechequeo.
+
+## Tablas de turnos y operaciones
+### turnos
+- `id` (PK)
+- `codigo` (varchar(16), único)
+- `planta_id`, `muelle_id`, `ventanilla_id`
+- `empresa_id`, `conductor_id`, `vehiculo_id`
+- `estado` (`TurnoEstado`)
+- `fecha_hora` (timestamptz) — inicio programado
+- `duracion_estimado` (interval)
+- `prioridad` (smallint, default 0)
+- `qr_url`, `comentarios`
+- `created_at`, `updated_at`
+- Índices por `planta_id`, `estado`, `fecha_hora` y parcial para estados activos.
+
+### turnos_historial
+- Registra cada transición con `estado_anterior`, `estado_nuevo`, `usuario_id`, `comentario`, `metadata` (jsonb).
+
+### turnos_documentos
+- Asociaciones con documentos requeridos (`documento_id`, `turno_id`, `estado_validacion`).
+
+### documentos
+- `id`, `tipo_documento`, `url`, `vigencia_desde`, `vigencia_hasta`, `verificado_por`, `estado`.
+
+### reglas
+- `id`, `planta_id`, `nombre`, `tipo_regla`, `condiciones_json`, `accion_json`, `prioridad`, `activa`, `vigencia_desde/hasta`.
+- Índices por `planta_id`, `activa`, `tipo_regla`.
+
+### bloqueos_calendario
+- Define cierres por planta/franja: `fecha`, `hora_inicio`, `hora_fin`, `motivo`, `capacidad_restante`.
+
+### cupos_planta
+- Plantas y franjas con capacidades (`capacidad_total`, `ocupacion_actual`).
+
+### asignaciones_muelle
+- Intervalos reales de atención: `turno_id`, `muelle_id`, `inicio_real`, `fin_real`, `observaciones`.
+
+### notificaciones
+- Log de envíos: `turno_id`, `canal`, `mensaje`, `estado_envio`, `intentos`, `payload`.
+
+### kpi_snapshots
+- Métricas agregadas por día/planta: `turnos_creados`, `confirmados`, `cancelados`, `sla_promedio`, `ocupacion_promedio`.
+
+### turno_eventos
+- Trazabilidad detallada (check-in, validaciones, alertas) con `tipo_evento` y `metadata`.
+
+## Índices recomendados
+- Índice compuesto `turnos(planta_id, fecha_hora)` filtrado por estados activos.
+- Índices GIN para columnas jsonb (`reglas.condiciones_json`, `accion_json`).
+- Índices por `empresa_id` y `estado` en `turnos` para dashboards de planners.
+
+## Migraciones y seed
+- Prisma `schema.prisma` incluye enums y relaciones con `@@index`/`@@unique`.
+- Script de seed crea roles base, planta demo, muelles, reglas iniciales y usuario admin.

--- a/docs/manual_usuario.md
+++ b/docs/manual_usuario.md
@@ -1,0 +1,56 @@
+# Manual de usuario
+
+## Introducción
+La plataforma permite agendar turnos de ingreso a planta, gestionar documentación y monitorear el estado de atención. Existen dos perfiles principales: usuarios externos (conductores/empresas) y personal interno (planners, operativos, guardias).
+
+## Acceso
+- URL: https://agendamiento.yumatech.online
+- Credenciales demo: `admin@demo.com` / `Admin123!`
+- Soporte para cambio de idioma y tema desde el perfil del usuario.
+
+## Panel de usuario (conductores/empresas)
+1. **Inicio**
+   - Selecciona planta, fecha y hora disponibles según capacidad y reglas activas.
+2. **Datos del turno**
+   - Ingresa cédula, nombre, placa y adjunta documentos requeridos.
+   - El sistema autocompleta si la cédula/placa ya existe en la base.
+3. **Confirmación**
+   - Verifica el resumen, recibe QR y confirmación automática por WhatsApp/email.
+4. **Mis turnos**
+   - Visualiza próximos turnos, puede cancelar o reprogramar dentro de la tolerancia.
+   - Si excede la ventana, se muestra el mensaje "Ya no puedes cancelar; contacta al operador".
+5. **Documentos**
+   - Gestiona licencias, SOAT, tecnomecánica y otros documentos con estado de vigencia.
+
+## Panel de administración
+1. **Dashboard**
+   - Métricas del día (turnos por estado, ocupación de muelles, SLA promedio).
+2. **Agenda**
+   - Vista semanal/diaria de turnos con drag & drop hacia muelles disponibles.
+   - Conflictos muestran toast de error; guardado automático con icono check.
+3. **Turnos**
+   - Listado con filtros avanzados (planta, estado, empresa, tipo vehículo).
+   - Acciones rápidas: confirmar, cancelar, registrar no show, reenviar confirmación.
+4. **Reglas**
+   - Crear, editar y activar/desactivar reglas por planta.
+   - Visualización de reglas activas con prioridad y vigencia.
+5. **Notificaciones**
+   - Historial de comunicaciones enviadas con iconografía por canal.
+   - Botón "Reenviar confirmación".
+6. **KPIs y simulador**
+   - Formularios para ajustar `cupos por franja` y `duración promedio`.
+   - Gráficos de proyección y tablas de resultados.
+
+## Operaciones en planta (guardias)
+- Módulo rápido para escanear QR, validar documentos pendientes y registrar ingreso.
+- Cambio de estado a `EN_PROCESO` al realizar check-in.
+- Registro de salida para cerrar turno.
+
+## Buenas prácticas
+- Mantener documentos actualizados para evitar rechazos.
+- Revisar notificaciones previas al turno y llegar dentro de la ventana asignada.
+- Administradores: monitorear alertas de capacidad y ajustar reglas cuando sea necesario.
+
+## Soporte
+- Canal de soporte interno disponible vía WhatsApp/Telegram.
+- Logs de auditoría permiten rastrear cualquier acción.

--- a/docs/reglas_y_kpi.md
+++ b/docs/reglas_y_kpi.md
@@ -1,0 +1,50 @@
+# Motor de reglas y KPIs
+
+## Motor de reglas
+- Se configura por planta con prioridad (`prioridad` numérica) y vigencia (`vigencia_desde`, `vigencia_hasta`).
+- Tipos soportados:
+  - `MAX_POR_EMPRESA`: limita turnos por empresa y franja.
+  - `BLOQUEO_TIPO_VEHICULO`: restringe tipos de vehículo en rangos de fechas.
+  - `PRIORIDAD_PROVEEDOR`: ajusta prioridad de atención.
+  - `DOCUMENTO_OBLIGATORIO`: valida que se adjunten documentos específicos.
+  - `CAPACIDAD_DIA` y `CAPACIDAD_FRANJA`: controla cupos globales.
+  - `TOLERANCIA_CANCELACION`: define ventana para cancelar sin penalidad.
+  - `VENTANILLA_OBLIGATORIA`: fuerza paso por ventanilla/prechequeo.
+- Acciones posibles: `RECHAZAR`, `PRIORIZAR`, `WARN` (solo notifica).
+- Evaluación en cadena: se ejecutan reglas activas ordenadas por prioridad, acumulando resultados y registrando auditoría.
+
+## Flujo de validación
+1. Reglas de capacidad bloquean si no hay cupos disponibles.
+2. Validaciones documentales revisan vigencias y estados (`documentos.estado`).
+3. Prioridades ajustan orden en agenda y asignación de muelles.
+4. Si alguna regla devuelve `RECHAZAR`, se informa el motivo al usuario.
+
+## KPIs operativos
+1. **Turnos creados:** `COUNT(*) FROM turnos WHERE created_at BETWEEN $from AND $to`.
+2. **Turnos confirmados:** porcentaje sobre turnos creados.
+3. **Turnos atendidos vs no show:** comparación `ATENDIDO` vs `NO_SHOW`.
+4. **Ocupación de muelles:** heatmap semanal con ocupación real vs capacidad.
+5. **Tiempo medio de atención:** diferencia entre `inicio_real` y `fin_real` de `asignaciones_muelle`.
+6. **Cancelaciones:** tasa por motivo (`CANCELADO_USUARIO`, `CANCELADO_ADMIN`).
+7. **Cumplimiento SLA:** `% de turnos atendidos dentro de su ventana de atención`.
+8. **Errores de reglas:** conteo de eventos `RULE_VIOLATION` por tipo de regla.
+
+## Simulador de capacidad
+- Inputs: `cupos_por_franja`, `duracion_promedio`, `horizonte_dias`, `distribucion_demanda`.
+- Calcula ocupación teórica vs real usando datos históricos y reglas activas.
+- Devuelve:
+  - Proyección de turnos confirmados por día.
+  - Recomendaciones de ajuste de cupos o apertura de muelles.
+  - Alertas de cuellos de botella si la demanda supera la capacidad > 80%.
+
+## Dashboard de análisis
+- **Turnos por estado:** gráfico de torta.
+- **Ocupación muelles:** heatmap semanal.
+- **Tiempo medio de atención:** gráfica lineal por día.
+- Filtros superiores por fecha, planta y tipo de vehículo.
+- Exportación a CSV y enlace a Power BI.
+
+## Alertas y notificaciones
+- Recordatorios automáticos 24h y 2h antes de la cita.
+- Alertas internas cuando la ocupación supera 90%.
+- Reporte diario vía email a planners con KPIs clave y simulación actualizada.

--- a/docs/seguridad_y_ci_cd.md
+++ b/docs/seguridad_y_ci_cd.md
@@ -1,0 +1,35 @@
+# Seguridad y CI/CD
+
+## Seguridad de la aplicación
+- Autenticación con Auth.js/NextAuth, soporte SSO corporativo (OIDC) y 2FA opcional.
+- RBAC granular con roles (`admin`, `planner`, `operativo`, `guardia`, `usuario`).
+- Rate limiting mediante Redis/Upstash; protección CSRF y headers con Helmet.
+- Validación exhaustiva de entradas con Zod y sanitización de datos.
+- Logs de auditoría con usuario, IP, acción, estado previo/posterior y `traceId`.
+- Cifrado en reposo para PII sensible (cédula, placa) y cifrado de secretos con Dotenv/SOPS.
+- Política de backups diarios y verificación periódica de restauración.
+
+## Seguridad operativa
+- Acceso a infraestructura con SSH + claves, MFA en paneles administrativos.
+- Monitoreo con alertas cuando se detectan errores críticos o tasa alta de rechazo.
+- Revisiones de dependencia (Dependabot) y escaneo Snyk/Trivy en pipeline.
+
+## Pipeline CI/CD
+1. **Lint & typecheck:** ESLint, Prettier, TypeScript.
+2. **Tests:** Vitest/Playwright y pruebas Prisma en base temporal.
+3. **Build:** compilación Next.js y generación de assets.
+4. **Deploy:** publicación a VPS mediante Docker Compose `pull` + `up -d`.
+5. **Post-deploy:** ejecutar migraciones (`prisma migrate deploy`) y healthcheck.
+
+## Infraestructura como código
+- Archivos en `deploy/` incluyen `docker-compose.yml`, `Caddyfile` y scripts.
+- Scripts `backup.sh` / `restore.sh` para administración de base de datos.
+- Variables sensibles se administran vía `.env` cifrado o secrets del proveedor.
+
+## Checklist previo a go-live
+- Todas las rutas sirviéndose bajo HTTPS.
+- Variables `.env` definidas sin valores por defecto inseguros.
+- Cuentas admin con 2FA activo y contraseñas rotadas.
+- Backups automatizados y restauración probada.
+- Monitoreo y alertas activos (Sentry, Healthchecks).
+- Pipeline CI/CD ejecutando pruebas antes de cada despliegue.

--- a/docs/ui_ux.md
+++ b/docs/ui_ux.md
@@ -1,0 +1,47 @@
+# Lineamientos UI/UX
+
+## Principios de diseño
+- Estilo profesional y artístico con modo claro/oscuro y paletas alternativas.
+- Enfoque mobile-first para conductores, con layouts responsive para planners.
+- Accesibilidad AA: contraste, navegación por teclado, labels claros, soporte lector de pantalla.
+- Microinteracciones sutiles (Framer Motion) en transiciones y feedback.
+- Internacionalización ES/EN desde el inicio con textos gestionados por i18next.
+
+## Flujos principales
+### Creación de turno (usuario)
+1. Selección de planta, fecha y hora disponibles.
+2. Formulario de datos (cédula, nombre, placa, tipo vehículo, documentos).
+3. Confirmación con resumen y generación de QR + WhatsApp.
+4. Pantalla de éxito con confeti ligero y CTA para ver turnos.
+
+### Gestión de turnos (planner)
+- Agenda tipo calendario con franjas y muelles.
+- Drag & drop de turnos a muelles disponibles; conflictos muestran toast de error.
+- Guardado automático con icono de verificación y estado de sincronización.
+
+### Validación documental
+- Listado de requisitos con estados (`pendiente`, `aprobado`, `vencido`).
+- Botón para solicitar reenvío o subir nuevamente.
+- Alertas visuales cuando falta documentación crítica.
+
+## Estados vacíos y errores
+- 404: mensaje "Ruta no encontrada 🧭" + botón a inicio.
+- 500: mensaje humano "Algo salió mal; intentemos otra vez." con acción de reintentar.
+- Empty states con mensajes claros y CTA relevantes (p.e. "No tienes turnos programados" → "Crear turno").
+
+## Componentes clave
+- Cards resumen de turnos con chips de estado y tiempo restante.
+- Timeline de eventos para auditoría en detalle de turno.
+- Sección "Comunicaciones enviadas" con iconografía por canal.
+- Botón "Reenviar confirmación" en detalle.
+- Heatmaps, pie charts y line charts cargados de forma lazy.
+
+## Feedback y accesibilidad
+- Skeleton loaders con animación shimmer para listados.
+- Tolerancia y tiempos mostrados en copy claro (ej. "Puedes cancelar hasta 2h antes").
+- Tooltips y ayudas contextuales para reglas y KPIs.
+
+## Internacionalización
+- Arquitectura con namespaces (`common`, `agenda`, `turnos`, `admin`).
+- Switch de idioma persistente por usuario (`usuarios.idioma`).
+- Formatos de fecha/hora adaptados al `timezone` de la planta.


### PR DESCRIPTION
## Summary
- crea un README principal con visión del sistema, módulos y estructura propuesta
- documenta la arquitectura, API, modelo de datos, reglas, seguridad y guía de usuario en la carpeta docs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e43246ae4c832bb6a4b685a376b9dc