### PR TITLE
Add Next.js demo application skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+node_modules
+.next
+out
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+.DS_Store
+.idea
+.vscode
+coverage
+artifacts

--- a/README.md
+++ b/README.md
@@ -1,61 +1,50 @@
 # Agendamiento Planta 1
 
 ## 🧭 Propósito
-Sistema web integral para gestionar el agendamiento de turnos de vehículos en planta. Permite a conductores y planners coordinar cupos, validar documentos, monitorear estados en tiempo real y analizar KPIs operativos.
+Sistema web integral para gestionar el agendamiento de turnos de vehículos en planta. Permite a conductores y planners coordinar
+cupos, validar documentos, monitorear estados en tiempo real y analizar KPIs operativos.
 
-## ⚙️ Tecnologías propuestas
-- **Frontend:** Next.js 15, React 19, TypeScript, TailwindCSS, shadcn/ui, Framer Motion, React Query, i18next.
-- **Backend:** Next.js API Routes, Prisma ORM, Zod, BullMQ (Redis) para colas, Webhooks.
-- **Infraestructura:** PostgreSQL 15, Redis, Docker Compose, Caddy como reverse proxy, OpenTelemetry, Sentry.
+## ⚙️ Tecnologías
+- **Frontend y backend**: Next.js 15 (App Router), React 19, TypeScript.
+- **UI**: Tailwind CSS, componentes propios inspirados en shadcn/ui.
+- **Estado y validaciones**: React Query (planificado), Zod/Prisma (planificado).
 
-## 🧱 Módulos clave
-1. Panel de usuario (creación, consulta, cancelación y reprogramación de turnos).
-2. Panel de administración con agenda en tiempo real, reglas y asignación de muelles.
-3. Motor de reglas dinámico con validaciones y priorizaciones.
-4. Gestión documental y validaciones automáticas.
-5. Sistema de notificaciones multicanal (WhatsApp, email, SMS opcional).
-6. KPIs y simulador de capacidad para análisis operativo.
+## 🧱 Módulos incluidos
+- Landing pública con resumen funcional.
+- Flujo demo de creación de turno para conductores.
+- Panel simulado para planners con lista de turnos.
+- Vista de KPIs con heatmap y simulador manual.
+- Endpoint de salud (`/api/health`) para monitoreo básico.
 
-## 🚀 Instalación rápida
-```bash
-git clone https://github.com/yumatech/agendamiento.git
-cd agendamiento
-cp .env.example .env
-docker compose up -d --build
-```
+> ℹ️ La lógica de negocio, persistencia y autenticación están representadas con datos simulados. Los módulos de API real, reglas dinámicas y colas se integrarán en siguientes iteraciones.
 
-### Desarrollo local
+## 🚀 Puesta en marcha
 ```bash
 npm install
 npm run dev
 ```
 
-### Pruebas y mantenimiento
-- `npm run test` — pruebas unitarias y E2E.
-- `npx prisma migrate deploy` — aplicar migraciones.
-- `npx prisma studio` — inspección de datos.
+Visita `http://localhost:3000` para explorar la interfaz demo.
 
-## 👤 Acceso demo
-- Usuario: `admin@demo.com`
-- Contraseña: `Admin123!`
+### Scripts disponibles
+- `npm run dev` — Ejecuta el entorno de desarrollo.
+- `npm run build` — Genera la build de producción.
+- `npm run start` — Sirve la build generada.
+- `npm run lint` — Ejecuta ESLint.
+- `npm run typecheck` — Verifica tipos TypeScript sin emitir artefactos.
 
-## 📁 Estructura propuesta del repositorio
+## 📁 Estructura del repositorio
 ```
-agendamiento/
-├── app/                     # Next.js (App Router + API)
-│   ├── app/                 # layouts, rutas públicas e internas
-│   ├── components/          # UI shadcn + componentes propios
-│   ├── features/            # módulos: turnos, reglas, admin, user
-│   ├── lib/                 # contratos, hooks, helpers, cliente API
-│   ├── server/              # servicios Prisma, reglas, colas
-│   ├── prisma/              # esquema y migraciones
-│   ├── public/              # assets estáticos
-│   └── tests/               # pruebas unitarias y E2E
-├── deploy/                  # infraestructura (docker, caddy, scripts)
-├── docs/                    # documentación funcional y técnica
-├── .env.example
-├── package.json
-└── README.md
+app/
+├── (app)/               # Áreas autenticadas (panel y KPIs)
+├── (public)/            # Flujo demo para conductores
+├── api/                 # Rutas serverless (healthcheck)
+├── layout.tsx           # Layout raíz
+└── page.tsx             # Landing principal
+components/              # UI reutilizable
+lib/                     # Utilidades y datos simulados
+public/                  # Assets estáticos (pendiente)
+docs/                    # Documentación técnica y funcional existente
 ```
 
 ## 📚 Documentación disponible
@@ -69,17 +58,14 @@ agendamiento/
 
 ## ✅ Checklist de entrega
 - Documentación funcional y técnica.
-- Esquema de base de datos y migraciones.
-- API y casos de uso principales.
-- UI/UX detallado con flujos clave.
-- Módulo de KPIs y simulador documentado.
-- Docker + CI/CD descritos.
-- Manual técnico y de usuario.
-- Seguridad, respaldos y monitoreo cubiertos.
+- UI navegable para los módulos clave descritos.
+- Simulación de turnos, reglas y KPIs en la interfaz.
+- Scripts de desarrollo y build configurados.
+- Endpoint de salud listo para integraciones de monitoreo.
 
 ## 🔭 Próximos pasos sugeridos
-- Integrar SSO corporativo (Azure AD / Keycloak).
-- Añadir permisos granulares por scopes.
-- Extender simulador con predicciones (Prophet).
-- Exponer API externa REST/GraphQL con OpenAPI.
-- Integrar con Power BI / Power Automate para reportes.
+- Conectar la app con una base de datos real y Prisma ORM.
+- Integrar autenticación corporativa (Azure AD / Keycloak).
+- Añadir motor de reglas dinámico y colas BullMQ.
+- Implementar API pública documentada con OpenAPI.
+- Automatizar despliegue con Docker, Caddy y pipelines CI/CD.

--- a/app/(app)/dashboard/appointments/page.tsx
+++ b/app/(app)/dashboard/appointments/page.tsx
@@ -1,0 +1,62 @@
+import Link from "next/link";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { buttonVariants } from "@/components/ui/button";
+import { mockAppointments } from "@/lib/mock-data";
+
+export default function AppointmentsPage() {
+  return (
+    <div className="mx-auto flex w-full max-w-5xl flex-col gap-8 px-6 py-12">
+      <header className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <div className="space-y-1">
+          <p className="text-xs uppercase tracking-[0.3em] text-brand-200">Agenda</p>
+          <h1 className="text-3xl font-semibold text-white">Turnos programados</h1>
+        </div>
+        <Link href="/appointments/new" className={buttonVariants()}>
+          Crear turno manual
+        </Link>
+      </header>
+
+      <Card>
+        <CardHeader
+          title="Resumen del día"
+          description="Filtra y gestiona los turnos activos, confirmados y pendientes de la jornada."
+        />
+        <CardContent>
+          <div className="space-y-4">
+            {mockAppointments.map((appointment) => (
+              <article
+                key={appointment.id}
+                className="flex flex-col gap-3 rounded-2xl border border-white/10 bg-white/5 p-4 md:flex-row md:items-center md:justify-between"
+              >
+                <div>
+                  <p className="text-sm text-brand-200">{appointment.id}</p>
+                  <p className="text-lg font-semibold text-white">{appointment.driver}</p>
+                  <p className="text-xs text-slate-400">Placa {appointment.plate}</p>
+                </div>
+                <div className="text-sm text-slate-300">
+                  <p>{appointment.dock}</p>
+                  <p>
+                    {new Date(appointment.scheduledAt).toLocaleTimeString("es-CO", {
+                      hour: "2-digit",
+                      minute: "2-digit"
+                    })}
+                  </p>
+                </div>
+                <div className="flex items-center gap-3">
+                  <span className="rounded-full bg-white/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide">
+                    {appointment.status}
+                  </span>
+                  <span className="text-xs text-slate-400">Tolerancia {appointment.toleranceMinutes} min</span>
+                </div>
+                <div className="flex gap-2 text-xs">
+                  <button className={buttonVariants({ variant: "ghost", size: "sm" })}>Reenviar confirmación</button>
+                  <button className={buttonVariants({ variant: "secondary", size: "sm" })}>Liberar muelle</button>
+                </div>
+              </article>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/(app)/dashboard/kpis/page.tsx
+++ b/app/(app)/dashboard/kpis/page.tsx
@@ -1,0 +1,112 @@
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { mockKpis } from "@/lib/mock-data";
+
+const heatmap = [
+  { day: "Lun", slots: [70, 65, 82, 90, 60] },
+  { day: "Mar", slots: [62, 68, 79, 88, 55] },
+  { day: "Mié", slots: [58, 74, 85, 92, 64] },
+  { day: "Jue", slots: [60, 71, 88, 94, 70] },
+  { day: "Vie", slots: [55, 66, 80, 86, 58] }
+];
+
+const slotLabels = ["06h", "08h", "10h", "12h", "14h"];
+
+export default function KpiPage() {
+  return (
+    <div className="mx-auto flex w-full max-w-5xl flex-col gap-10 px-6 py-12">
+      <header className="space-y-2">
+        <p className="text-xs uppercase tracking-[0.3em] text-brand-200">Análisis</p>
+        <h1 className="text-3xl font-semibold text-white">KPIs y simulador</h1>
+        <p className="text-sm text-slate-300">
+          Evalúa la eficiencia operativa con métricas clave y simula escenarios de capacidad antes de cambios en la
+          planta.
+        </p>
+      </header>
+
+      <section className="grid gap-4 md:grid-cols-3">
+        {mockKpis.map((kpi) => (
+          <Card key={kpi.label}>
+            <CardHeader title={kpi.label} description={kpi.trend} />
+            <CardContent>
+              <p className="text-4xl font-semibold text-white">{kpi.value}</p>
+            </CardContent>
+          </Card>
+        ))}
+      </section>
+
+      <section className="grid gap-6 lg:grid-cols-[1.2fr_1fr]">
+        <Card className="bg-white/5">
+          <CardHeader title="Ocupación de muelles" description="Mapa de calor semanal (datos simulados)" />
+          <CardContent>
+            <div className="overflow-x-auto">
+              <table className="w-full min-w-[400px] border-collapse text-sm">
+                <thead>
+                  <tr>
+                    <th className="pb-3 text-left text-xs uppercase tracking-wide text-slate-400">Día</th>
+                    {slotLabels.map((label) => (
+                      <th key={label} className="pb-3 text-xs uppercase tracking-wide text-slate-400">
+                        {label}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-white/5">
+                  {heatmap.map((row) => (
+                    <tr key={row.day}>
+                      <td className="py-2 pr-4 text-slate-200">{row.day}</td>
+                      {row.slots.map((value, index) => (
+                        <td key={index}>
+                          <div
+                            className="h-10 rounded-2xl"
+                            style={{
+                              background: `linear-gradient(135deg, rgba(48,127,255,${value / 120}), rgba(20,47,108,0.8))`,
+                              color: value > 75 ? "white" : "#cbd5f5",
+                              display: "flex",
+                              alignItems: "center",
+                              justifyContent: "center",
+                              fontWeight: 600
+                            }}
+                          >
+                            {value}%
+                          </div>
+                        </td>
+                      ))}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader
+            title="Simulador rápido"
+            description="Ajusta parámetros para estimar capacidad disponible durante el día."
+          />
+          <CardContent>
+            <form className="space-y-4 text-sm">
+              <div className="space-y-2">
+                <label className="text-slate-300" htmlFor="capacity">Cupos por franja</label>
+                <input id="capacity" name="capacity" type="number" defaultValue={8} className="input" />
+              </div>
+              <div className="space-y-2">
+                <label className="text-slate-300" htmlFor="duration">Duración promedio (min)</label>
+                <input id="duration" name="duration" type="number" defaultValue={45} className="input" />
+              </div>
+              <div className="space-y-2">
+                <label className="text-slate-300" htmlFor="noShow">No show esperado (%)</label>
+                <input id="noShow" name="noShow" type="number" defaultValue={5} className="input" />
+              </div>
+              <button type="button" className="mt-4 w-full rounded-2xl bg-brand-500 py-2 font-semibold text-white">
+                Calcular capacidad
+              </button>
+              <p className="text-xs text-slate-400">
+                Los resultados se integrarán con el motor de reglas en futuras iteraciones.
+              </p>
+            </form>
+          </CardContent>
+        </Card>
+      </section>
+    </div>
+  );
+}

--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -1,0 +1,86 @@
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { mockAppointments } from "@/lib/mock-data";
+
+export default function DashboardPage() {
+  return (
+    <div className="mx-auto flex w-full max-w-5xl flex-col gap-10 px-6 py-12">
+      <header className="space-y-2">
+        <p className="text-xs uppercase tracking-[0.3em] text-brand-200">Operación en vivo</p>
+        <h1 className="text-3xl font-semibold text-white">Panel de planta</h1>
+        <p className="text-sm text-slate-300">
+          Visualiza las citas del día, tolerancias y estados operativos para tomar decisiones inmediatas.
+        </p>
+      </header>
+
+      <section className="grid gap-4 md:grid-cols-3">
+        <Card>
+          <CardHeader title="Turnos activos" description="En proceso dentro de planta" />
+          <CardContent>
+            <p className="text-4xl font-semibold text-white">6</p>
+            <p className="text-xs text-slate-400">2 en muelle prioritario</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader title="Capacidad restante" description="Cupos disponibles en la jornada" />
+          <CardContent>
+            <p className="text-4xl font-semibold text-white">12</p>
+            <p className="text-xs text-slate-400">Actualizar reglas si baja de 8</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader title="Alertas" description="Eventos que requieren seguimiento" />
+          <CardContent>
+            <ul className="space-y-2 text-sm">
+              <li>⚠️ Llegada tardía — TUR-24005</li>
+              <li>ℹ️ Documento SOAT por vencer</li>
+            </ul>
+          </CardContent>
+        </Card>
+      </section>
+
+      <section className="space-y-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-white">Turnos del día</h2>
+          <p className="text-xs text-slate-400">Datos simulados a modo demostrativo</p>
+        </div>
+        <div className="overflow-hidden rounded-3xl border border-white/10">
+          <table className="min-w-full divide-y divide-white/10 text-left text-sm text-slate-200">
+            <thead className="bg-white/5 text-xs uppercase tracking-wide text-slate-300">
+              <tr>
+                <th className="px-4 py-3">Turno</th>
+                <th className="px-4 py-3">Conductor</th>
+                <th className="px-4 py-3">Placa</th>
+                <th className="px-4 py-3">Muelle</th>
+                <th className="px-4 py-3">Estado</th>
+                <th className="px-4 py-3">Horario</th>
+                <th className="px-4 py-3">Tolerancia</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-white/5 bg-slate-950/60">
+              {mockAppointments.map((appointment) => (
+                <tr key={appointment.id}>
+                  <td className="px-4 py-3 font-medium text-white">{appointment.id}</td>
+                  <td className="px-4 py-3">{appointment.driver}</td>
+                  <td className="px-4 py-3">{appointment.plate}</td>
+                  <td className="px-4 py-3">{appointment.dock}</td>
+                  <td className="px-4 py-3">
+                    <span className="rounded-full bg-white/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide">
+                      {appointment.status}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3">
+                    {new Date(appointment.scheduledAt).toLocaleTimeString("es-CO", {
+                      hour: "2-digit",
+                      minute: "2-digit"
+                    })}
+                  </td>
+                  <td className="px-4 py-3">{appointment.toleranceMinutes} min</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/(public)/appointments/new/page.tsx
+++ b/app/(public)/appointments/new/page.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import Link from "next/link";
+import { useState, type ReactNode } from "react";
+import { buttonVariants } from "@/components/ui/button";
+
+const timeSlots = ["06:00", "06:30", "07:00", "07:30", "08:00", "08:30"];
+const docks = ["Muelle 1", "Muelle 2", "Muelle 3", "Muelle 4"];
+const cargoTypes = ["General", "Refrigerado", "Peligroso", "Contenedor vacío"];
+
+type Step = "details" | "confirmation";
+
+export default function AppointmentFormPage() {
+  const [step, setStep] = useState<Step>("details");
+
+  return (
+    <div className="mx-auto flex w-full max-w-3xl flex-col gap-8 px-6 py-12">
+      <header className="space-y-2">
+        <p className="text-xs uppercase tracking-[0.2em] text-brand-200">Agendamiento</p>
+        <h1 className="text-3xl font-semibold text-white">Solicitar turno demo</h1>
+        <p className="text-sm text-slate-300">
+          Completa los datos del conductor y la carga para simular un turno. No se guardan datos reales, es un flujo de
+          demostración.
+        </p>
+      </header>
+
+      {step === "details" ? <DetailsStep onContinue={() => setStep("confirmation")} /> : null}
+      {step === "confirmation" ? <ConfirmationStep onBack={() => setStep("details")} /> : null}
+    </div>
+  );
+}
+
+function DetailsStep({ onContinue }: { onContinue: () => void }) {
+  return (
+    <form
+      className="space-y-8 rounded-3xl border border-white/10 bg-white/5 p-8 shadow-xl shadow-black/30"
+      onSubmit={(event) => {
+        event.preventDefault();
+        onContinue();
+      }}
+    >
+      <section className="grid gap-4 md:grid-cols-2">
+        <div className="space-y-2">
+          <label className="text-sm text-slate-300" htmlFor="plant">
+            Planta
+          </label>
+          <select id="plant" name="plant" className="input">
+            <option>Planta Norte</option>
+            <option>Planta Centro</option>
+          </select>
+        </div>
+        <div className="space-y-2">
+          <label className="text-sm text-slate-300" htmlFor="dock">
+            Muelle preferido
+          </label>
+          <select id="dock" name="dock" className="input">
+            {docks.map((dock) => (
+              <option key={dock}>{dock}</option>
+            ))}
+          </select>
+        </div>
+        <div className="space-y-2">
+          <label className="text-sm text-slate-300" htmlFor="date">
+            Fecha
+          </label>
+          <input id="date" name="date" type="date" className="input" required />
+        </div>
+        <div className="space-y-2">
+          <label className="text-sm text-slate-300" htmlFor="time">
+            Hora estimada de llegada
+          </label>
+          <select id="time" name="time" className="input">
+            {timeSlots.map((slot) => (
+              <option key={slot}>{slot}</option>
+            ))}
+          </select>
+        </div>
+      </section>
+
+      <section className="grid gap-4 md:grid-cols-2">
+        <div className="space-y-2">
+          <label className="text-sm text-slate-300" htmlFor="driverId">
+            Cédula / Documento
+          </label>
+          <input id="driverId" name="driverId" type="text" className="input" placeholder="123456789" required />
+        </div>
+        <div className="space-y-2">
+          <label className="text-sm text-slate-300" htmlFor="driverName">
+            Nombre del conductor
+          </label>
+          <input id="driverName" name="driverName" type="text" className="input" placeholder="Juan Pérez" required />
+        </div>
+        <div className="space-y-2">
+          <label className="text-sm text-slate-300" htmlFor="plate">
+            Placa del vehículo
+          </label>
+          <input id="plate" name="plate" type="text" className="input" placeholder="ABC123" required />
+        </div>
+        <div className="space-y-2">
+          <label className="text-sm text-slate-300" htmlFor="cargoType">
+            Tipo de carga
+          </label>
+          <select id="cargoType" name="cargoType" className="input">
+            {cargoTypes.map((type) => (
+              <option key={type}>{type}</option>
+            ))}
+          </select>
+        </div>
+      </section>
+
+      <section className="space-y-3">
+        <p className="text-sm text-slate-200">Documentos requeridos</p>
+        <div className="grid gap-3 md:grid-cols-2">
+          <CheckboxItem label="Licencia de conducción vigente" />
+          <CheckboxItem label="SOAT / Seguro obligatorio" />
+          <CheckboxItem label="Certificado de fumigación" />
+          <CheckboxItem label="Póliza de responsabilidad civil" />
+        </div>
+      </section>
+
+      <div className="flex flex-wrap gap-3">
+        <button type="submit" className={buttonVariants({ size: "lg" })}>
+          Confirmar datos
+        </button>
+        <LinkButton href="/">Cancelar</LinkButton>
+      </div>
+    </form>
+  );
+}
+
+function ConfirmationStep({ onBack }: { onBack: () => void }) {
+  return (
+    <div className="space-y-8 rounded-3xl border border-emerald-400/20 bg-emerald-500/10 p-8 text-slate-100">
+      <div className="space-y-3">
+        <h2 className="text-2xl font-semibold text-white">¡Turno demo confirmado!</h2>
+        <p className="text-sm text-emerald-200">
+          Simulamos el envío de un QR al conductor y la notificación a planta. Puedes regresar para ajustar los datos o
+          explorar el panel administrativo.
+        </p>
+      </div>
+      <div className="rounded-2xl border border-white/20 bg-white/10 p-6">
+        <p className="text-sm text-slate-200">
+          Recuerda que esta es una simulación. Para conectarlo con tu infraestructura real, consulta la sección de API y
+          despliegue en la documentación técnica.
+        </p>
+      </div>
+      <div className="flex flex-wrap gap-3">
+        <LinkButton href="/dashboard">Ir al panel</LinkButton>
+        <button type="button" className={buttonVariants({ variant: "secondary" })} onClick={onBack}>
+          Crear otro turno
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function CheckboxItem({ label }: { label: string }) {
+  const [checked, setChecked] = useState(false);
+
+  return (
+    <label className="flex items-start gap-3 rounded-2xl border border-white/10 bg-white/5 p-4 text-sm text-slate-200">
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(event) => setChecked(event.target.checked)}
+        className="mt-1 h-4 w-4 rounded border border-white/40 bg-slate-950"
+      />
+      <span>{label}</span>
+    </label>
+  );
+}
+
+function LinkButton({ href, children }: { href: string; children: ReactNode }) {
+  return (
+    <Link href={href} className={buttonVariants({ variant: "secondary" })}>
+      {children}
+    </Link>
+  );
+}

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  return NextResponse.json({ status: "ok", environment: process.env.NODE_ENV ?? "development" });
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,24 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light;
+}
+
+body {
+  @apply bg-slate-950 text-slate-100 antialiased;
+  font-feature-settings: "rlig" 1, "calt" 1;
+}
+
+a {
+  @apply text-brand-400 underline-offset-2 transition-colors hover:text-brand-300;
+}
+
+main {
+  @apply min-h-screen;
+}
+
+.input {
+  @apply h-11 w-full rounded-2xl border border-white/10 bg-slate-900/60 px-4 text-sm text-slate-100 outline-none transition focus:border-brand-400 focus:ring-2 focus:ring-brand-500/40;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,32 @@
+import type { Metadata } from "next";
+import "./globals.css";
+import { ReactNode } from "react";
+import { MainNav } from "@/components/navigation/main-nav";
+
+export const metadata: Metadata = {
+  title: "Agendamiento Planta 1",
+  description:
+    "Plataforma integral para gestionar turnos, reglas y analítica operativa en planta.",
+  metadataBase: new URL("https://example.com")
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="es" suppressHydrationWarning>
+      <body className="bg-slate-950 text-slate-100">
+        <div className="flex min-h-screen flex-col">
+          <MainNav />
+          <main className="flex-1">{children}</main>
+          <footer className="border-t border-white/10 bg-slate-900/60 backdrop-blur">
+            <div className="mx-auto flex w-full max-w-5xl flex-col gap-2 px-6 py-8 text-sm text-slate-400 md:flex-row md:items-center md:justify-between">
+              <p>© {new Date().getFullYear()} Agendamiento Planta 1. Todos los derechos reservados.</p>
+              <p className="text-xs text-slate-500">
+                Documentación técnica disponible en la carpeta <code>/docs</code> del repositorio.
+              </p>
+            </div>
+          </footer>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,107 @@
+import Link from "next/link";
+import { buttonVariants } from "@/components/ui/button";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { mockKpis, mockRules } from "@/lib/mock-data";
+
+const highlights = [
+  {
+    title: "Agenda inteligente",
+    description:
+      "Configura franjas horarias dinámicas, reglas por tipo de carga y validaciones automáticas antes del check-in.",
+    cta: { label: "Simula capacidad", href: "/dashboard/kpis" }
+  },
+  {
+    title: "Operación en tiempo real",
+    description:
+      "Visualiza los muelles ocupados, reasigna turnos con drag & drop y comunica al instante los cambios al conductor.",
+    cta: { label: "Ver panel", href: "/dashboard" }
+  },
+  {
+    title: "Analítica operativa",
+    description:
+      "Mide SLA, ocupación y cuellos de botella para planificar con datos y anticiparte a los picos de demanda.",
+    cta: { label: "KPIs", href: "/dashboard/kpis" }
+  }
+];
+
+export default function HomePage() {
+  return (
+    <div className="mx-auto flex w-full max-w-5xl flex-col gap-16 px-6 py-16">
+      <section className="grid gap-10 lg:grid-cols-[1.4fr_1fr] lg:items-center">
+        <div className="space-y-6">
+          <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-1 text-xs uppercase tracking-wide text-brand-200">
+            Gestión integral de turnos
+          </span>
+          <h1 className="text-4xl font-bold leading-tight text-white sm:text-5xl">
+            Coordina tu planta con precisión minuto a minuto
+          </h1>
+          <p className="text-lg text-slate-300">
+            Centraliza la programación de citas, controla la asignación de muelles y anticipa la demanda con un motor
+            de reglas configurable y KPIs accionables.
+          </p>
+          <div className="flex flex-wrap gap-3">
+            <Link href="/appointments/new" className={buttonVariants()}>
+              Crear turno demo
+            </Link>
+            <Link href="/dashboard" className={buttonVariants({ variant: "secondary" })}>
+              Explorar panel
+            </Link>
+          </div>
+          <div className="rounded-2xl border border-white/5 bg-white/[0.04] p-5 text-sm text-slate-300">
+            <p className="font-semibold text-white">¿Qué obtienes?</p>
+            <ul className="mt-3 space-y-2">
+              <li>✔️ Validación de documentos y tolerancias configurables.</li>
+              <li>✔️ Reglas dinámicas por tipo de carga, muelle o cliente.</li>
+              <li>✔️ Notificaciones omnicanal y seguimiento post-cita.</li>
+            </ul>
+          </div>
+        </div>
+        <div className="space-y-4 rounded-3xl border border-brand-500/40 bg-gradient-to-br from-brand-500/20 via-slate-900 to-slate-900 p-6">
+          <h2 className="text-xl font-semibold text-white">KPIs destacados</h2>
+          <div className="space-y-3">
+            {mockKpis.map((kpi) => (
+              <div key={kpi.label} className="rounded-2xl border border-white/10 bg-white/10 p-4">
+                <p className="text-sm text-slate-300">{kpi.label}</p>
+                <p className="text-3xl font-bold text-white">{kpi.value}</p>
+                <p className="text-xs text-brand-200">{kpi.trend}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="grid gap-6 md:grid-cols-3">
+        {highlights.map((item) => (
+          <Card key={item.title}>
+            <CardHeader title={item.title} />
+            <CardContent>
+              <p>{item.description}</p>
+              <Link href={item.cta.href} className={buttonVariants({ variant: "ghost", size: "sm" })}>
+                {item.cta.label}
+              </Link>
+            </CardContent>
+          </Card>
+        ))}
+      </section>
+
+      <section className="space-y-6">
+        <div className="flex flex-col gap-2">
+          <h2 className="text-2xl font-semibold text-white">Reglas activas</h2>
+          <p className="text-sm text-slate-300">
+            Configuraciones claves que garantizan el flujo operativo y el cumplimiento de tolerancias.
+          </p>
+        </div>
+        <div className="grid gap-4 md:grid-cols-2">
+          {mockRules.map((rule) => (
+            <Card key={rule.name} className="bg-white/8">
+              <CardHeader title={rule.name} description={rule.description} />
+              <CardContent>
+                <p className="text-xs text-slate-400">Última edición: {rule.lastUpdatedBy}</p>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/components/navigation/main-nav.tsx
+++ b/components/navigation/main-nav.tsx
@@ -1,0 +1,42 @@
+import Link from "next/link";
+
+const links = [
+  { href: "/", label: "Inicio" },
+  { href: "/appointments/new", label: "Agenda un turno" },
+  { href: "/dashboard", label: "Panel" },
+  { href: "/dashboard/kpis", label: "KPIs" }
+];
+
+export function MainNav() {
+  return (
+    <header className="border-b border-white/10 bg-slate-900/80 backdrop-blur">
+      <div className="mx-auto flex w-full max-w-5xl items-center justify-between px-6 py-4">
+        <Link href="/" className="flex items-center gap-2 text-lg font-semibold text-white">
+          <span className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-brand-500 text-sm font-bold">
+            AP1
+          </span>
+          Agendamiento Planta 1
+        </Link>
+        <nav className="hidden gap-6 text-sm font-medium text-slate-300 md:flex">
+          {links.map((link) => (
+            <Link
+              key={link.href}
+              href={link.href}
+              className="rounded-full px-3 py-1 transition-colors hover:bg-white/10 hover:text-white"
+            >
+              {link.label}
+            </Link>
+          ))}
+        </nav>
+        <div className="flex items-center gap-3">
+          <Link
+            href="/appointments/new"
+            className="rounded-full bg-brand-500 px-4 py-1.5 text-sm font-semibold text-white shadow-lg shadow-brand-500/30 transition hover:bg-brand-400"
+          >
+            Crear turno
+          </Link>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,0 +1,39 @@
+import { type ButtonHTMLAttributes, forwardRef } from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center rounded-full text-sm font-semibold transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2",
+  {
+    variants: {
+      variant: {
+        primary: "bg-brand-500 text-white hover:bg-brand-400 focus-visible:outline-brand-300",
+        secondary: "bg-white/10 text-white hover:bg-white/20 focus-visible:outline-white",
+        ghost: "text-slate-200 hover:bg-white/10"
+      },
+      size: {
+        sm: "h-9 px-4",
+        md: "h-10 px-6",
+        lg: "h-12 px-8 text-base"
+      }
+    },
+    defaultVariants: {
+      variant: "primary",
+      size: "md"
+    }
+  }
+);
+
+export interface ButtonProps
+  extends ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {}
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, ...props }, ref) => (
+    <button ref={ref} className={cn(buttonVariants({ variant, size }), className)} {...props} />
+  )
+);
+
+Button.displayName = "Button";
+
+export { buttonVariants };

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,0 +1,23 @@
+import { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+export function Card({ className, children }: { className?: string; children: ReactNode }) {
+  return (
+    <div className={cn("rounded-3xl border border-white/10 bg-white/5 p-6 shadow-lg shadow-black/40", className)}>
+      {children}
+    </div>
+  );
+}
+
+export function CardHeader({ title, description }: { title: string; description?: string }) {
+  return (
+    <div className="mb-4 space-y-1">
+      <h3 className="text-lg font-semibold text-white">{title}</h3>
+      {description ? <p className="text-sm text-slate-300">{description}</p> : null}
+    </div>
+  );
+}
+
+export function CardContent({ children }: { children: ReactNode }) {
+  return <div className="space-y-3 text-sm text-slate-200">{children}</div>;
+}

--- a/docs/arquitectura.md
+++ b/docs/arquitectura.md
@@ -36,8 +36,10 @@ El sistema combina un frontend Next.js 15 (App Router) y un backend basado en ru
 
 ## Respaldo y continuidad
 - Backups automáticos usando `pg_dump` y posible integración con `restic`.
-- Scripts de `deploy/scripts/backup.sh` y `restore.sh` para recuperación rápida.
+- Planificado: Scripts de `deploy/scripts/backup.sh` y `restore.sh` para recuperación rápida.
 - Estrategia de retención 30/90 días y pruebas periódicas de restauración.
+
+> **Nota:** Los scripts `deploy/scripts/backup.sh` y `deploy/scripts/restore.sh` aún no forman parte del repositorio y serán incorporados en entregables futuros.
 
 ## Roadmap técnico
 - Implementar SSO corporativo (Azure AD/Keycloak).

--- a/docs/seguridad_y_ci_cd.md
+++ b/docs/seguridad_y_ci_cd.md
@@ -22,9 +22,11 @@
 5. **Post-deploy:** ejecutar migraciones (`prisma migrate deploy`) y healthcheck.
 
 ## Infraestructura como código
-- Archivos en `deploy/` incluyen `docker-compose.yml`, `Caddyfile` y scripts.
-- Scripts `backup.sh` / `restore.sh` para administración de base de datos.
+- Planificado: Archivos en `deploy/` incluirán `docker-compose.yml`, `Caddyfile` y scripts.
+- Planificado: Scripts `backup.sh` / `restore.sh` para administración de base de datos.
 - Variables sensibles se administran vía `.env` cifrado o secrets del proveedor.
+
+> **Nota:** Los archivos `deploy/docker-compose.yml`, `deploy/Caddyfile`, `deploy/scripts/backup.sh` y `deploy/scripts/restore.sh` aún no existen en el repositorio actual y se entregarán en un hito posterior.
 
 ## Checklist previo a go-live
 - Todas las rutas sirviéndose bajo HTTPS.

--- a/lib/mock-data.ts
+++ b/lib/mock-data.ts
@@ -1,0 +1,60 @@
+export const mockAppointments = [
+  {
+    id: "TUR-24001",
+    driver: "Carlos Pérez",
+    plate: "ABC123",
+    dock: "Muelle 3",
+    status: "Confirmado",
+    scheduledAt: "2024-09-12T08:00:00Z",
+    toleranceMinutes: 15
+  },
+  {
+    id: "TUR-24002",
+    driver: "María Gómez",
+    plate: "XYZ987",
+    dock: "Muelle 1",
+    status: "En proceso",
+    scheduledAt: "2024-09-12T09:30:00Z",
+    toleranceMinutes: 10
+  },
+  {
+    id: "TUR-24003",
+    driver: "Luis Rodríguez",
+    plate: "JKL456",
+    dock: "Muelle 2",
+    status: "Pendiente",
+    scheduledAt: "2024-09-12T11:00:00Z",
+    toleranceMinutes: 20
+  }
+];
+
+export const mockKpis = [
+  {
+    label: "SLA cumplido",
+    value: "92%",
+    trend: "+4% vs. semana anterior"
+  },
+  {
+    label: "Ocupación muelles",
+    value: "78%",
+    trend: "-3% vs. objetivo"
+  },
+  {
+    label: "Cancelaciones",
+    value: "12",
+    trend: "2 reprogramadas"
+  }
+];
+
+export const mockRules = [
+  {
+    name: "Planta Norte — Prioridad perecederos",
+    description: "Los turnos de productos refrigerados tienen prioridad entre 6:00 y 9:00 am.",
+    lastUpdatedBy: "Ana Ruiz"
+  },
+  {
+    name: "Bloqueo mantenimiento Muelle 4",
+    description: "No se asignan turnos entre el 15 y 16 de septiembre por mantenimiento preventivo.",
+    lastUpdatedBy: "Juan Martínez"
+  }
+];

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,10 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    typedRoutes: true,
+    instrumentationHook: true
+  }
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "agendamiento-planta-1",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@tanstack/react-query": "^5.51.5",
+    "class-variance-authority": "^0.7.0",
+    "clsx": "^2.1.1",
+    "next": "^15.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "tailwind-merge": "^2.5.2"
+  },
+  "devDependencies": {
+    "@types/node": "^20.16.5",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "autoprefixer": "^10.4.20",
+    "eslint": "^9.9.0",
+    "eslint-config-next": "^15.0.0",
+    "postcss": "^8.4.47",
+    "tailwindcss": "^3.4.13",
+    "typescript": "^5.5.4"
+  }
+}

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,34 @@
+import type { Config } from "tailwindcss";
+import { fontFamily } from "tailwindcss/defaultTheme";
+
+const config: Config = {
+  content: [
+    "./app/**/*.{js,ts,jsx,tsx,mdx}",
+    "./components/**/*.{js,ts,jsx,tsx,mdx}",
+    "./lib/**/*.{js,ts,jsx,tsx,mdx}"
+  ],
+  theme: {
+    extend: {
+      colors: {
+        brand: {
+          50: "#f2f9ff",
+          100: "#d9edff",
+          200: "#b3d8ff",
+          300: "#85beff",
+          400: "#589eff",
+          500: "#307fff",
+          600: "#1d61e6",
+          700: "#154bc0",
+          800: "#153d92",
+          900: "#142f6c"
+        }
+      },
+      fontFamily: {
+        sans: ["Inter", ...fontFamily.sans]
+      }
+    }
+  },
+  plugins: []
+};
+
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "es2022"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    },
+    "types": ["node", "react/experimental", "react-dom/experimental"]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- bootstrap a Next.js 15 + Tailwind workspace with shared layout, navigation, and UI utilities
- add simulated appointment flow, planner dashboard, and KPI views driven by mock data
- refresh the README with setup guidance and expose a basic `/api/health` endpoint

## Testing
- not run (Node.js dependencies are not installed in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68e43820b044832bb92dfa05c66a0c30